### PR TITLE
Update windex.htaccess to hide "windex"

### DIFF
--- a/windex.htaccess
+++ b/windex.htaccess
@@ -8,6 +8,7 @@
 #========================================================================
 
 Options +Indexes
+IndexIgnore windex
 
 IndexOptions FancyIndexing
 IndexOptions FoldersFirst IgnoreCase XHTML NameWidth=*


### PR DESCRIPTION
This might just be a personal preference, but it would be nice to hide the 'windex' directory from the actual directory listing.
